### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM guergeiro/pnpm:lts-latest-alpine
+
+# Install dependencies
+WORKDIR /app
+COPY ./frontend/package.json ./frontend/pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+# Copy all local files into the image.
+COPY ./frontend/. .
+
+# This makes svelte's adapter-auto think that we are in a
+# Google Cloud Run environment, which makes it pick adapter-node
+ENV GCP_BUILDPACKS="1"
+
+# Build app
+RUN pnpm run build
+
+# Expose default node port (3000)
+EXPOSE 3000
+
+# Launch with dotenv config
+CMD ["node", "./build"]


### PR DESCRIPTION
This commit adds a Dockerfile for node-based deployment.

It uses [`guergeiro/pnpm:lts-latest-alpine`](https://hub.docker.com/r/guergeiro/pnpm) as a base, which is a node+pnpm package on Alpine Linux.

I didn't want to change your svelte adapter config, so I used a dummy `GCP_BUILDPACK` environment variable to trick the svelte adapter-auto into using the node adapter (see https://github.com/GoogleCloudPlatform/buildpacks/issues/381#issuecomment-2155647422).