### PR TITLE
add "strip metadata" option

### DIFF
--- a/frontend/src/components/file-display.svelte
+++ b/frontend/src/components/file-display.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import type { ParsedOutput } from "$lib/types/parsed-output";
-    import { onMount } from 'svelte';
+    import { removeMetadata } from '$lib/utils/remove-metadata';
+    import { onDestroy } from 'svelte';
 
     export let fileUrl: string;
     export let currentFile: File | null;
@@ -10,10 +11,45 @@
     let searchTerm = '';
     let filteredOutput: ParsedOutput = [];
 
+    let stripping = false;
+    let stripError: string | null = null;
+    let strippedFileName: string | null = null;
+    let strippedUrl: string | null = null;
+
+    function resetStrippedResult() {
+        if (strippedUrl) {
+            URL.revokeObjectURL(strippedUrl);
+        }
+        strippedUrl = null;
+        strippedFileName = null;
+        stripError = null;
+    }
+
     $: if (currentFile) {
         // Reset scroll position when file changes
         if (container) {
             container.scrollTop = 0;
+        }
+        resetStrippedResult();
+    }
+
+    onDestroy(() => {
+        if (strippedUrl) URL.revokeObjectURL(strippedUrl);
+    });
+
+    async function handleStripMetadata() {
+        if (!currentFile) return;
+        stripping = true;
+        resetStrippedResult();
+        try {
+            const { blob, fileName } = await removeMetadata(currentFile);
+            strippedUrl = URL.createObjectURL(blob);
+            strippedFileName = fileName;
+        } catch (error) {
+            console.error('Error removing metadata:', error);
+            stripError = 'Something went wrong removing metadata. Please try again.';
+        } finally {
+            stripping = false;
         }
     }
 
@@ -66,6 +102,30 @@
                 <div class="flex justify-center items-center h-full text-gray-500 font-mono text-sm md:text-base">
                     exiftool could not properly be run on this file.
                 </div>
+            {/if}
+        </div>
+
+        <div class="border-t border-gray-300 pt-4 flex flex-col gap-2">
+            <button
+                class="self-start border-2 border-gray-300 rounded px-4 py-2 font-mono text-sm hover:border-blue-500 hover:bg-blue-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                on:click={handleStripMetadata}
+                disabled={stripping}
+            >
+                {stripping ? 'Removing metadata…' : 'Strip metadata'}
+            </button>
+
+            {#if stripError}
+                <p class="text-sm text-red-600 font-mono">{stripError}</p>
+            {/if}
+
+            {#if strippedUrl && strippedFileName}
+                <a
+                    href={strippedUrl}
+                    download={strippedFileName}
+                    class="self-start text-sm font-mono text-blue-600 underline"
+                >
+                    Download {strippedFileName}
+                </a>
             {/if}
         </div>
     {:else}

--- a/frontend/src/lib/utils/remove-metadata.ts
+++ b/frontend/src/lib/utils/remove-metadata.ts
@@ -1,0 +1,53 @@
+import { runPerl, escapePerlString } from './run-perl';
+
+export interface RemoveMetadataResult {
+	blob: Blob;
+	fileName: string;
+}
+
+async function removeMetadata(browserFile: globalThis.File): Promise<RemoveMetadataResult> {
+	try {
+		const fileName = browserFile.name;
+		const imageData = await browserFile.arrayBuffer();
+        const outputFileName = `stripped-${fileName}`;
+		const escapedFileName = escapePerlString(fileName);
+		const escapedOutputFileName = escapePerlString(outputFileName);
+
+		const perlScript = `
+        use Image::ExifTool;
+        my $exifTool = Image::ExifTool->new();
+
+        $exifTool->SetNewValue('*');
+
+        my $ok = $exifTool->WriteInfo("${escapedFileName}", "${escapedOutputFileName}");
+        if ($ok) {
+            print "OK\\n";
+        } else {
+            print "Error: " . $exifTool->GetValue("Error") . "\\n";
+        }
+        `;
+
+		const { stdout, stderr, fs } = await runPerl(perlScript, [
+			{ name: fileName, data: new Uint8Array(imageData) }
+		]);
+
+		if (!stdout.includes('OK')) {
+			throw new Error(`Failed to strip metadata: ${stdout}${stderr}`);
+		}
+
+		const outputFile = fs.get(outputFileName);
+		if (!outputFile) {
+			throw new Error(`Expected output file "${outputFileName}" was not produced`);
+		}
+
+		return {
+			blob: new Blob([outputFile.data], { type: browserFile.type || 'application/octet-stream' }),
+			fileName: outputFileName
+		};
+	} catch (error) {
+		console.error('Error removing metadata:', error);
+		throw new Error('Failed to remove metadata', { cause: error });
+	}
+}
+
+export { removeMetadata };

--- a/frontend/src/lib/utils/run-exif-tools.ts
+++ b/frontend/src/lib/utils/run-exif-tools.ts
@@ -1,37 +1,12 @@
-import { WASI, WASIProcExit } from '@bjorn3/browser_wasi_shim';
+import { runPerl, escapePerlString } from './run-perl';
 import { parseExifOutput } from './parse-exif-output';
-import { PreopenDirectory, File } from '@bjorn3/browser_wasi_shim';
-import { instantiate } from './asyncify.js';
-import { Fd } from '@bjorn3/browser_wasi_shim';
 import type { ParsedOutput } from '$lib/types/parsed-output';
-import { fetchZeroPerl } from './fetch-zeroperl';
-
-class CustomFd extends Fd {
-	private collectedOutput = '';
-
-	fd_write(data: Uint8Array): { ret: number; nwritten: number } {
-		const text = new TextDecoder().decode(data);
-		console.log('WASI output:', text); // Debug output
-		this.collectedOutput += text;
-		return { ret: 0, nwritten: data.length };
-	}
-
-	getOutput(): string {
-		return this.collectedOutput;
-	}
-}
 
 async function runExifTools(browserFile: globalThis.File): Promise<ParsedOutput> {
 	try {
 		const fileName = browserFile.name;
 		const imageData = await browserFile.arrayBuffer();
-
-		// Escape special characters for Perl double-quoted string
-		const escapedFileName = fileName
-			.replace(/\\/g, '\\\\')
-			.replace(/"/g, '\\"')
-			.replace(/\$/g, '\\$')
-			.replace(/@/g, '\\@');
+		const escapedFileName = escapePerlString(fileName)
 
 		const perlScript = `
         use Image::ExifTool;
@@ -50,69 +25,14 @@ async function runExifTools(browserFile: globalThis.File): Promise<ParsedOutput>
         }
         `;
 
-		const stdout = new CustomFd();
-		const stderr = new CustomFd();
-
-		// Create virtual filesystem with image file
-		const filesMap = new Map([
-			[fileName, new File(new Uint8Array(imageData))]
+		const { stdout } = await runPerl(perlScript, [
+			{ name: fileName, data: new Uint8Array(imageData) }
 		]);
 
-		// Create WASI instance with increased memory limits
-		const wasi = new WASI(
-			['perl', '-e', perlScript],
-			['LC_ALL=C', 'PERL_UNICODE=SD'], // Added PERL_UNICODE for better string handling
-			[
-				new CustomFd(), // stdin (fd 0)
-				stdout, // stdout (fd 1)
-				stderr, // stderr (fd 2)
-				new PreopenDirectory('/dev', new Map([['null', new File(new Uint8Array())]])),
-				new PreopenDirectory('.', filesMap)
-			],
-			{
-				debug: true
-			}
-		);
-
-		// Set up imports with memory configuration
-		const imports = {
-			wasi_snapshot_preview1: wasi.wasiImport,
-			env: {
-				memory: new WebAssembly.Memory({
-					initial: 100, // Initial memory in pages (6.4MB)
-					maximum: 1000, // Maximum memory in pages (64MB)
-					shared: false
-				})
-			}
-		};
-
-		// In browser we'll need to fetch the wasm file
-		const wasmBuffer = await fetchZeroPerl();
-
-		console.log('Loading WASM...');
-		const { instance } = await instantiate(wasmBuffer, imports);
-		console.log('WASM loaded successfully');
-
-		try {
-			wasi.start(instance as { exports: { memory: WebAssembly.Memory; _start: () => void } });
-		} catch (e) {
-			if (e instanceof WASIProcExit) {
-				console.log(`ExifTool exited with code ${e.code}`);
-				if (e.code !== 0) {
-					console.error('ExifTool error:', stderr.getOutput());
-					throw new Error(`ExifTool exited with code ${e.code}`);
-				}
-			} else {
-				throw e;
-			}
-		}
-
-		const output = stdout.getOutput();
-		const parsedOutput = parseExifOutput(output);
-		return parsedOutput;
+		return parseExifOutput(stdout)
 	} catch (error) {
 		console.error('Error running ExifTool:', error);
-		throw new Error('Failed to run ExifTool');
+		throw new Error('Failed to run ExifTool', { cause: error });
 	}
 }
 

--- a/frontend/src/lib/utils/run-perl.ts
+++ b/frontend/src/lib/utils/run-perl.ts
@@ -1,0 +1,89 @@
+import { WASI, WASIProcExit, PreopenDirectory, File, Fd } from '@bjorn3/browser_wasi_shim';
+import { instantiate } from './asyncify.js';
+import { fetchZeroPerl } from './fetch-zeroperl';
+
+class CustomFd extends Fd {
+	private collectedOutput = '';
+
+	fd_write(data: Uint8Array): { ret: number; nwritten: number } {
+		const text = new TextDecoder().decode(data);
+        console.log('WASI output:', text); // Debug output
+		this.collectedOutput += text;
+		return { ret: 0, nwritten: data.length };
+	}
+
+	getOutput(): string {
+		return this.collectedOutput;
+	}
+}
+
+export function escapePerlString(value: string): string {
+	return value
+		.replace(/\\/g, '\\\\')
+		.replace(/"/g, '\\"')
+		.replace(/\$/g, '\\$')
+		.replace(/@/g, '\\@');
+}
+
+export interface PerlInputFile {
+	name: string;
+	data: Uint8Array;
+}
+
+export interface RunPerlResult {
+	stdout: string;
+	stderr: string;
+    fs: Map<string, File>;
+}
+
+export async function runPerl(script: string, inputFiles: PerlInputFile[]): Promise<RunPerlResult> {
+	const stdout = new CustomFd();
+	const stderr = new CustomFd();
+
+	const fs = new Map<string, File>(inputFiles.map((f) => [f.name, new File(f.data)]));
+
+	const wasi = new WASI(
+		['perl', '-e', script],
+		['LC_ALL=C', 'PERL_UNICODE=SD'], // Added PERL_UNICODE for better string handling
+		[
+			new CustomFd(), // stdin (fd 0)
+			stdout, // stdout (fd 1)
+			stderr, // stderr (fd 2)
+			new PreopenDirectory('/dev', new Map([['null', new File(new Uint8Array())]])),
+			new PreopenDirectory('.', fs)
+		],
+		{ debug: false }
+	);
+
+    // Set up imports with memory configuration
+	const imports = {
+		wasi_snapshot_preview1: wasi.wasiImport,
+		env: {
+			memory: new WebAssembly.Memory({
+				initial: 100, // Initial memory in pages (6.4MB)
+				maximum: 1000, // Maximum memory in pages (64MB)
+				shared: false
+			})
+		}
+	};
+
+	const wasmBuffer = await fetchZeroPerl();
+
+	console.log('Loading WASM...');
+	const { instance } = await instantiate(wasmBuffer, imports);
+	console.log('WASM loaded successfully');
+
+	try {
+		wasi.start(instance as { exports: { memory: WebAssembly.Memory; _start: () => void } });
+	} catch (e) {
+		if (e instanceof WASIProcExit) {
+			if (e.code !== 0) {
+				throw new Error(`perl exited with code ${e.code}: ${stderr.getOutput()}`);
+			}
+		} else {
+			throw e;
+		}
+	}
+
+	return { stdout: stdout.getOutput(), stderr: stderr.getOutput(), fs };
+}


### PR DESCRIPTION
Copies most of run-exif-tools into helper file and adds button to strip metadata. 

<img width="700" alt="Screenshot 2026-08-05 at 3 14 43 PM" src="https://github.com/user-attachments/assets/bd5b7ceb-a1a0-4538-b129-49fdc3c15dc8" />

Also, I spent a while trying to figure out why Mac PNG screenshots crash the WASM module with `RuntimeError: memory access out of bounds` (even when just reading with original code). I think I traced it to the file's ICC profile. If I strip the ICC chunk locally first (with `exiftool -icc_profile:all= -o no_icc.png FILE`), then reupload works. 
I think it's because screenshots use Apple's "Color LCD" display profile. That description is stored as an ICC record with ~40 language variants. I think this larger record is hitting the WASM's stack size/initial memory limits (it works on local exiftool). It may be worth a later PR but I think it's edge casey enough to be fine. 
